### PR TITLE
[sc-33724] Reduce Canada Ingest frequence into Datalake

### DIFF
--- a/lib/dynamodb-continuous-incremental-exports-stack.ts
+++ b/lib/dynamodb-continuous-incremental-exports-stack.ts
@@ -454,8 +454,17 @@ export class DynamoDbContinuousIncrementalExportsStack extends cdk.NestedStack {
   private async sanityChecks() {
     //await this.dynamoDbSanityChecks();
 
-    if (this.configuration.incrementalExportWindowSizeInMinutes < 15 || this.configuration.incrementalExportWindowSizeInMinutes > 3*24*60) {
-      throw new Error(`incrementalExportWindowSizeInMinutes has to be between 15 minutes and 4,320 minutes (72h)`);
+    const MIN_INCREMENTAL_EXPORT_WINDOW_MINUTES = 15;
+    const MAX_INCREMENTAL_EXPORT_WINDOW_MINUTES = 3 * 24 * 60;
+    const MAX_INCREMENTAL_EXPORT_WINDOW_HOURS = MAX_INCREMENTAL_EXPORT_WINDOW_MINUTES / 60;
+
+    if (
+      this.configuration.incrementalExportWindowSizeInMinutes < MIN_INCREMENTAL_EXPORT_WINDOW_MINUTES ||
+      this.configuration.incrementalExportWindowSizeInMinutes > MAX_INCREMENTAL_EXPORT_WINDOW_MINUTES
+    ) {
+      throw new Error(
+        `incrementalExportWindowSizeInMinutes has to be between ${MIN_INCREMENTAL_EXPORT_WINDOW_MINUTES} minutes and ${MAX_INCREMENTAL_EXPORT_WINDOW_MINUTES.toLocaleString('en-US')} minutes (${MAX_INCREMENTAL_EXPORT_WINDOW_HOURS}h)`
+      );
     }
   }
 

--- a/lib/dynamodb-continuous-incremental-exports-stack.ts
+++ b/lib/dynamodb-continuous-incremental-exports-stack.ts
@@ -454,8 +454,8 @@ export class DynamoDbContinuousIncrementalExportsStack extends cdk.NestedStack {
   private async sanityChecks() {
     //await this.dynamoDbSanityChecks();
 
-    if (this.configuration.incrementalExportWindowSizeInMinutes < 15 || this.configuration.incrementalExportWindowSizeInMinutes > 24*60) {
-      throw new Error(`incrementalExportWindowSizeInMinutes has to be between 15 minutes and 1,440 minutes (24h)`);
+    if (this.configuration.incrementalExportWindowSizeInMinutes < 15 || this.configuration.incrementalExportWindowSizeInMinutes > 3*24*60) {
+      throw new Error(`incrementalExportWindowSizeInMinutes has to be between 15 minutes and 4,320 minutes (72h)`);
     }
   }
 


### PR DESCRIPTION
Raises the upper bound in sanityChecks() from 1,440 minutes (24 h) to 4,320 minutes (72 h / 3 days) to support the Canada Stage and Canada Production environments that will be configured with a 3-day export window.