### PR TITLE
[sc-34082] Upgrade Lambda runtime from Node.js 20.x to 24.x

### DIFF
--- a/lib/dynamodb-continuous-incremental-exports-stack.ts
+++ b/lib/dynamodb-continuous-incremental-exports-stack.ts
@@ -414,7 +414,7 @@ export class DynamoDbContinuousIncrementalExportsStack extends cdk.NestedStack {
     return new lambda.Function(this, 'incremental-export-time-manipulator', {
       code: lambda.Code.fromAsset('./lib/runtime/continuousIncrementalExportsTimeManipulator'),
       handler: 'index.handler',
-      runtime: lambda.Runtime.NODEJS_22_X,
+      runtime: lambda.Runtime.NODEJS_24_X,
       architecture: lambda.Architecture.ARM_64,
       role: incrementalExportTimeManipulatorLambdaExecutionRole,
       logGroup: incrementalExportTimeManipulatorLogGroup


### PR DESCRIPTION
## Summary
Updated the Lambda function runtime for the incremental export time manipulator from Node.js 22.x to Node.js 24.x.

## Changes
- Updated `incremental-export-time-manipulator` Lambda function runtime from `NODEJS_22_X` to `NODEJS_24_X`

## Details
This change upgrades the Node.js runtime version used by the DynamoDB continuous incremental exports time manipulator Lambda function to the latest available version, ensuring access to newer language features, performance improvements, and security updates provided by Node.js 24.x.

https://claude.ai/code/session_01DKZNfuunT1sAvz4Y14rRb4